### PR TITLE
Support for MSVC (Windows)

### DIFF
--- a/fm_tune.c
+++ b/fm_tune.c
@@ -125,7 +125,7 @@ float run(SoapySDRDevice *sdr, SoapySDRStream *rx_stream, const float sample_rat
     nco_crcf shifter = nco_crcf_create(LIQUID_VCO);
     nco_crcf_set_frequency(shifter, M_PI*2.0*shift/sample_rate);
 
-    complex float buff[1024];
+    liquid_float_complex buff[1024];
     float wav;
 
     void *buffs[] = {buff, NULL};
@@ -141,7 +141,7 @@ float run(SoapySDRDevice *sdr, SoapySDRStream *rx_stream, const float sample_rat
                 exit(EXIT_FAILURE);
             }
         } else {
-            ret = read(STDIN_FILENO, buff, 1024 * sizeof (complex float));
+            ret = read(STDIN_FILENO, buff, 1024 * sizeof (liquid_float_complex));
             if (ret < 0) {
                 perror("read error");
                 exit(EXIT_FAILURE);
@@ -150,7 +150,7 @@ float run(SoapySDRDevice *sdr, SoapySDRStream *rx_stream, const float sample_rat
                 printf("EOF");
                 exit(EXIT_FAILURE);
             }
-            ret /= sizeof (complex float);
+            ret /= sizeof (liquid_float_complex);
         }
 
         for (int i=0; i<ret; i++) {
@@ -183,7 +183,7 @@ float run(SoapySDRDevice *sdr, SoapySDRStream *rx_stream, const float sample_rat
                 if ((shift_direction == UP && current_avg < 0) ||
                     (shift_direction == DOWN && current_avg > 0)) {
                     shift_size /= 10;
-                    shift_direction = -shift_direction;
+                    shift_direction = (enum Direction) (-1 * (int)shift_direction);
                 }
 
                 if (shift_size <= 1) {


### PR DESCRIPTION
Simply replacing `complex float` with `liquid_float_complex` made it possible to compile this program with MSVC.

**But** in C++ mode only. Hence this ugly cast was needed too:
`shift_direction = (enum Direction) (-1 * (int)shift_direction);`

It seems to work fine; `fm_tune.exe 104.5`:
```
...
Found device #0: driver=rtlsdr, label=Generic RTL2832U OEM :: 00000001, manufacturer=Silver, product=RTL2838-Silver, serial=00000001, tuner=Rafa
el Micro R820T,
[INFO] Opening Generic RTL2832U OEM :: 00000001...
Rx freq ranges: [2.3999e+07 Hz -> 1.764e+09 Hz],
[INFO] Using format CF32.
decimation: 36
Current avg: 0.000425, shift: 0.000000, scale: 1000.000000
Current avg: -0.001400, shift: -1000.000000, scale: 1000.000000
Current avg: -0.001489, shift: -900.000000, scale: 100.000000
Current avg: -0.000429, shift: -800.000000, scale: 100.000000
Current avg: -0.000954, shift: -700.000000, scale: 100.000000
Current avg: -0.000854, shift: -600.000000, scale: 100.000000
Current avg: -0.000714, shift: -500.000000, scale: 100.000000
Current avg: -0.000533, shift: -400.000000, scale: 100.000000
Current avg: -0.000413, shift: -300.000000, scale: 100.000000
Current avg: -0.000079, shift: -200.000000, scale: 100.000000
Current avg: 0.000124, shift: -100.000000, scale: 100.000000
Current avg: 0.000004, shift: -110.000000, scale: 10.000000
Current avg: -0.000257, shift: -120.000000, scale: 10.000000
Done, final shift: -120.000000
Done, expected: 1.045e+08 Hz, found at: 1.045e+08 Hz
PPM: -1
```